### PR TITLE
Update call to Pane::addItem

### DIFF
--- a/lib/git-control.coffee
+++ b/lib/git-control.coffee
@@ -32,7 +32,7 @@ module.exports = GitControl =
       views.push view
 
       pane = atom.workspace.getActivePane()
-      item = pane.addItem view, 0
+      item = pane.addItem view, {index: 0}
 
       pane.activateItem item
 


### PR DESCRIPTION
Following the recommendation of Atoms Deprecation-Cop.
Updated line 35 and changed second parameter from '0' to '{index: 0}'
This fixes #